### PR TITLE
Provide user with information about Temp\Simulation directory

### DIFF
--- a/as4_to_as6_analyzer.py
+++ b/as4_to_as6_analyzer.py
@@ -511,6 +511,8 @@ def main():
                     log(f"\nHardware configuration: {config_name}")
                     for name, path in sorted(entries):
                         log(f"- {name}: {path}")
+
+                log("\nOn ARsim, the drive letters now all point to the 'Temp\Simulation' directory!")
             else:
                 log("- None")
 


### PR DESCRIPTION
Instead of just warning about the invalid drive letters, let them know about the new path for the simulation file system