### PR TITLE
Add warning for OPC UA Implicit Type Cast default change (AS4->AS6)

### DIFF
--- a/checks/opc_ua.py
+++ b/checks/opc_ua.py
@@ -92,7 +92,7 @@ def check_uad_files(root_dir: Path, log, verbose=False) -> None:
                     # Check if ImplicitTypeCast parameter is explicitly set
                     # In AS4, the default is "on" (parameter not present means activated)
                     # In AS6, the default is "deactivated"
-                    # If the parameter is not present, warn the user about the behavior change
+                    # If the parameter is not present, inform the user about the behavior change
                     implicit_typecast_param = root_element.xpath(
                         ".//*[local-name()='Parameter'][@ID='OpcUaConversions_ImplicitTypeCast']"
                     )


### PR DESCRIPTION
## Summary
Adds a warning for the OPC UA Implicit Type Cast parameter default change between AS4 and AS6.

## Problem
In AS4, the "OPC-UA System -> Conversions -> Implicit Type Cast" option is **activated by default**. In AS6, this default has changed to **deactivated**. This can cause `Bad_TypeMismatch` errors during OPC UA client method calls when there are type mismatches (e.g., Int64 on server side vs Int32 on B&R side).

## Solution
- Check if the `OpcUaConversions_ImplicitTypeCast` parameter is explicitly set in hardware files
- If OPC UA is activated but this parameter is not present (using AS4 default), show an informative warning
- The warning includes the path to the setting in AS configuration for easy reference

## Output example
```
[INFO] "OPC-UA System -> Conversions -> Implicit Type Cast" uses AS4 default (on). In AS6, the default is deactivated, which may cause 'Bad_TypeMismatch' errors during OPC UA client method calls (e.g., Int64 to Int32 conversions).
The following hardware files use the AS4 default:

- C:\projects\...\Cpu.hw
```

Fixes #114