### PR TITLE
fix: preserve original file encoding when modifying source files

### DIFF
--- a/helpers/asmath_to_asbrmath.py
+++ b/helpers/asmath_to_asbrmath.py
@@ -12,8 +12,9 @@ def replace_functions_and_constants(
     """
     Replace function calls and constants in a file based on the provided mappings.
     """
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     function_replacements = 0
     constant_replacements = 0
@@ -34,13 +35,9 @@ def replace_functions_and_constants(
         )
         constant_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return function_replacements, constant_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{function_replacements + constant_replacements:4d} changes written to: {file_path}",
             severity="INFO",

--- a/helpers/asopcua_update.py
+++ b/helpers/asopcua_update.py
@@ -15,8 +15,9 @@ def replace_enums(file_path: Path, enum_mapping: dict) -> tuple[int, bool]:
     if any(part in {"AsOpcUac", "AsOpcUas"} for part in file_path.parts):
         return 0, False
 
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     enum_replacements = 0
 
@@ -29,13 +30,9 @@ def replace_enums(file_path: Path, enum_mapping: dict) -> tuple[int, bool]:
         )
         enum_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return enum_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{enum_replacements :4d} changes written to: {file_path}", severity="INFO"
         )
@@ -53,8 +50,9 @@ def replace_fbs_and_types(
     if any(part in {"AsOpcUac", "AsOpcUas"} for part in file_path.parts):
         return 0, 0, False
 
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     fb_replacements = 0
     type_replacements = 0
@@ -77,13 +75,9 @@ def replace_fbs_and_types(
         )
         type_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return fb_replacements, type_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{fb_replacements + type_replacements:4d} changes written to: {file_path}",
             severity="INFO",

--- a/helpers/asstring_to_asbrstr.py
+++ b/helpers/asstring_to_asbrstr.py
@@ -12,8 +12,9 @@ def replace_functions_and_constants(
     """
     Replace function calls and constants in a file based on the provided mappings.
     """
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
 
     modified_content = original_content
     function_replacements = 0
@@ -38,13 +39,9 @@ def replace_functions_and_constants(
         )
         constant_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return function_replacements, constant_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{function_replacements + constant_replacements:4d} changes written to: {file_path}",
             severity="INFO",

--- a/helpers/mappmotion_update.py
+++ b/helpers/mappmotion_update.py
@@ -32,8 +32,9 @@ def replace_enums(file_path: Path, enum_mapping, verbose=False):
     Replace enumerators in a file based on the provided mappings.
     """
 
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     enum_replacements = 0
 
@@ -51,13 +52,9 @@ def replace_enums(file_path: Path, enum_mapping, verbose=False):
             )
         enum_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return enum_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{enum_replacements :4d} changes written to: {file_path}", severity="INFO"
         )
@@ -70,8 +67,9 @@ def replace_inputs(file_path: Path, input_mapping, verbose=False):
     """
     Replace various FUB-inputs in code based on the provided mappings
     """
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     input_replacements = 0
 
@@ -91,13 +89,10 @@ def replace_inputs(file_path: Path, input_mapping, verbose=False):
             )
         input_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return input_replacements, False
-
-        log(
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
+        utils.log(
             f"{input_replacements:4d} change(s) written to: {file_path}",
             severity="INFO",
         )
@@ -113,8 +108,9 @@ def replace_fbs_and_types(
     Replace function block calls and types in a file based on the provided mappings.
     """
 
-    original_hash = utils.calculate_file_hash(file_path)
-    original_content = utils.read_file(file_path)
+    original_content, original_encoding, original_bytes = utils.read_file_with_encoding(
+        file_path
+    )
     modified_content = original_content
     fb_replacements = 0
     type_replacements = 0
@@ -168,13 +164,9 @@ def replace_fbs_and_types(
             )
         type_replacements += num_replacements
 
-    if modified_content != original_content:
-        file_path.write_text(modified_content, encoding="iso-8859-1")
-
-        new_hash = utils.calculate_file_hash(file_path)
-        if original_hash == new_hash:
-            return fb_replacements, type_replacements, False
-
+    if utils.write_file_if_changed(
+        file_path, modified_content, original_encoding, original_bytes
+    ):
         utils.log(
             f"{fb_replacements + type_replacements:4d} change(s) written to: {file_path}",
             severity="INFO",


### PR DESCRIPTION
Previously, helper scripts (asmath_to_asbrmath, asstring_to_asbrstr, asopcua_update, mappmotion_update) always wrote files as iso-8859-1, which corrupted German Umlaute and other special characters in UTF-8 files.

Changes:
- Add read_file_with_encoding() that detects and returns original encoding
- Add write_file_if_changed() that only writes if bytes actually changed
- Use from_bytes() instead of from_path() to avoid double file reads
- Update all helper scripts to preserve original file encoding
- Fix existing bug: log() -> utils.log() in mappmotion_update.py

This ensures:
- UTF-8 files with Umlaute (ä, ö, ü) are preserved correctly
- Legacy iso-8859-1/Latin-1 files from older AS versions work correctly
- No false positives in git (unchanged files stay unchanged)

Fixes issue with German Umlaute being erased when using helper scripts.