### PR TITLE
ab_2_st_converter: Ignore unknown arguments

### DIFF
--- a/helpers/ab_2_st_converter.py
+++ b/helpers/ab_2_st_converter.py
@@ -1775,7 +1775,7 @@ Examples:
         help="Disable equals to assignment conversion",
     )
 
-    return parser.parse_args()
+    return parser.parse_known_args()[0]
 
 
 def apply_config_from_args(args):


### PR DESCRIPTION
* --verbose is not an argument, but can be set via the GUI
* instead of defining it, make it resilient against ALL unknown args and parse only known args instead.

Note: Return type of parse_known_args() is a tuple, which is why we return element [0] of it

Fixes: https://github.com/br-automation-community/as6-migration-tools/issues/122