### PR TITLE
break caused that only the first .content file was analyzed

### DIFF
--- a/checks/mapp_analyzer.py
+++ b/checks/mapp_analyzer.py
@@ -30,7 +30,6 @@ def mapp_license_analyzer(project_path: Path):
                     for obj in result["mappView"]["breaseWidgets"]:
                         if "widgets.brease." + obj["name"] in line:
                             obj["cnt"] += 1
-                break
 
     services = utils.load_file_info("licenses", "mapp_services")
     result["mappServices"] = {"services": []}


### PR DESCRIPTION
Only the first .content file in the mappView folder was analyzed. Not all (or even none) widgets which require a license were listed in the report.
Before
<img width="830" height="402" alt="image" src="https://github.com/user-attachments/assets/7db00452-0636-473c-b388-1bbddc904672" />
After
<img width="837" height="583" alt="image" src="https://github.com/user-attachments/assets/5f408f36-f4e5-4dc4-b686-abfaed575d9f" />

