### PR TITLE
Match the whole words in text

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -228,7 +228,7 @@ def extract_urls(text):
 def linkify(text):
     links = get_links()
     for link in links:
-        if link in text:
+        if re.search(rf"\b{re.escape(link)}\b", text):
             text = text.replace(link, url(link))
     urls = extract_urls(text)
     for u in urls:


### PR DESCRIPTION
Match only the whole words links in text. For example not match "widgets.brease.OnlineChart" in text "widgets.brease.OnlineChartHDA used 57 times"
Before
<img width="836" height="589" alt="image" src="https://github.com/user-attachments/assets/8cfe0b97-f5de-466f-bc38-afd950b3412a" />
After
<img width="831" height="591" alt="image" src="https://github.com/user-attachments/assets/a6ce4679-0282-43b2-b5d9-c397e3588b43" />
