### PR TITLE
Skip trailing code in select statements

### DIFF
--- a/helpers/ab_2_st_converter.py
+++ b/helpers/ab_2_st_converter.py
@@ -990,7 +990,27 @@ def fix_select(file_path: Path) -> int:
             leading, nxt = m.group(1), m.group(2)
             tail = _strip_eol(line[m.end() :])  # keep comment/semicolon order exactly
             if current_select:
+                # Look ahead: if there is code between this NEXT and the next STATE/ENDSELECT,
+                # insert 'continue;' before END_IF so that trailing code is skipped.
+                has_code_after = False
+                for j in range(i + 1, len(lines)):
+                    look = lines[j].strip()
+                    if not look:
+                        continue  # skip blank lines
+                    if (
+                        state_prefix.match(lines[j])
+                        or sel_prefix.match(lines[j])
+                        or re.match(
+                            r"^\s*(ENDSELECT|END_CASE)\b", lines[j], re.IGNORECASE
+                        )
+                    ):
+                        break  # reached next STATE/SELECT/ENDSELECT/END_CASE — no code in between
+                    has_code_after = True
+                    break
+
                 new_lines.append(f"{leading}{current_select} := {nxt}{tail}\n")
+                if has_code_after:
+                    new_lines.append(f"{leading}continue;\n")
                 new_lines.append(f"{leading}END_IF\n")
                 total += 1
             else:


### PR DESCRIPTION
- Look ahead for code between state transitions
- Insert continue statement to skip trailing logic
- Ensures correct execution flow in converted code