### PR TITLE
Revert "Discontinuations: Generic ACOPOSmulti upgrades need replaceme…

### DIFF
--- a/discontinuations/unsupported_hw.json
+++ b/discontinuations/unsupported_hw.json
@@ -633,14 +633,6 @@
     "8I44xxxxxxx.xxx-1",
     "8I84xxxxxxx.01P-1"
   ],
-  "ACOPOSmulti - Generic variants with -x no longer supported with AS 6.x - Replace with -1, -3 or -4": [
-    "8BVIxxxxxxDS.xxx-x",
-    "8BVIxxxxxxDx.xxx-x",
-    "8BVIxxxxxxSA.xxx-x",
-    "8BVIxxxxxxSS.xxx-x",
-    "8BVIxxxxxxSx.xxx-x",
-    "8BVPxxxxxxxx.xxx-x"
-  ],
   "8LS motors - No longer supported with AS 6.x": [
     "8LSA25.E8060D000-0",
     "8LSA25.E8060D200-0",


### PR DESCRIPTION
…nt (#141)"

This reverts commit a793db8a537b405df1ab02e7fcadd82cabe592bd.

* Older AS6 versions threw a message about them being unsupported, but they can be added to AS6 anyway
* Reason for this: They were supposed to be discontinued, but effectively weren't

  Note: AS 6.5 doesn't throw the discontinuation message anymore Older AS6(.3, .1) need the modules to be removed and added again